### PR TITLE
helm3 に移行

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Build container images
           command: |
-            docker build \
+            docker build --no-cache \
               --tag "${DOCKERHUB_ORG_NAME}/${CIRCLE_PROJECT_REPONAME}:${version}" \
               --build-arg VCS_REF=`git rev-parse --short HEAD` \
               --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Build container images
           command: |
-            docker build --no-cache \
+            docker build \
               --tag "${DOCKERHUB_ORG_NAME}/${CIRCLE_PROJECT_REPONAME}:${version}" \
               --build-arg VCS_REF=`git rev-parse --short HEAD` \
               --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-        version: 18.06.0-ce
+        version: "19.03.8"
       # - *install_docker_client
       - run:
           name: Build container images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: "19.03.8"
+          version: 20.10.6
+          docker_layer_caching: true
       - run:
           name: Build container images
           command: |
@@ -45,7 +46,8 @@ jobs:
     steps:
       - *attach_workspace
       - setup_remote_docker:
-          version: "19.03.8"
+          version: 20.10.6
+          docker_layer_caching: true
       - run:
           name: Load Docker image from workspaces
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-        version: "19.03.8"
+          version: "19.03.8"
       # - *install_docker_client
       - run:
           name: Build container images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
           version: "19.03.8"
       # - *install_docker_client
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - *install_docker_client
+        version: 18.06.0-ce
+      # - *install_docker_client
       - run:
           name: Build container images
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,6 @@ references:
       REPO_PATH: "${ORG_PATH}/${CIRCLE_PROJECT_REPONAME}"
       BASH_ENV: .circleci/checktag.sh
       MICROBADGER_WEBHOOK_TOKEN: DHeKGmZSIcRzSjqDzYkeEPsLZpk=
-  install_docker_client: &install_docker_client
-    run:
-      name: Install docker client
-      command: |
-        set -x
-        VER="18.06.1-ce"
-        curl -L -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-        tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-        mv /tmp/docker/* /usr/bin
   attach_workspace: &attach_workspace
     attach_workspace:
       at: ~/images
@@ -30,7 +21,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: "19.03.8"
-      # - *install_docker_client
       - run:
           name: Build container images
           command: |
@@ -54,8 +44,8 @@ jobs:
     <<: *container_config
     steps:
       - *attach_workspace
-      - setup_remote_docker
-      - *install_docker_client
+      - setup_remote_docker:
+          version: "19.03.8"
       - run:
           name: Load Docker image from workspaces
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,6 @@ LABEL maintainer="Bitkey Inc." \
 # timezone
 RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# parallel
-RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
-    && tar -xvjf parallel-20210722.tar.bz2
-WORKDIR /parallel-20210722
-RUN ./configure \
-    && make \
-    && make install
-
 # google-cloud-sdk
 RUN pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib pandas google-cloud-monitoring==0.34.0 \
     && curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN pip install google-api-python-client google-auth-httplib2 google-auth-oauthl
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # helm
-RUN curl https://storage.googleapis.com/kubernetes-helm/helm-v2.14.1-linux-amd64.tar.gz | tar zx linux-amd64/helm \
+# 既存のスクリプトの動作を考慮し、　helm3 を helm コマンドとして実行可能にする
+RUN wget https://get.helm.sh/helm-v3.6.0-linux-amd64.tar.gz && tar xzf helm-v3.6.0-linux-amd64.tar.gz \
   && mv linux-amd64/helm /usr/local/bin/helm \
   && rm -rf linux-amd64
-RUN helm init -c --stable-repo-url https://charts.helm.sh/stable
 
 # jq
 RUN curl -o /usr/local/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,14 @@ LABEL maintainer="Bitkey Inc." \
 # timezone
 RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
+# parallel
+RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
+    && tar -xvjf parallel-20210722.tar.bz2
+WORKDIR /parallel-20210722
+RUN ./configure \
+    && make \
+    && make install
+
 # google-cloud-sdk
 RUN pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib pandas google-cloud-monitoring==0.34.0 \
     && curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz  \
@@ -27,14 +35,6 @@ RUN wget https://get.helm.sh/helm-v3.6.0-linux-amd64.tar.gz && tar xzf helm-v3.6
 # jq
 RUN curl -o /usr/local/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
     && chmod +x /usr/local/bin/jq
-
-# parallel
-RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
-    && tar -xvjf parallel-20210722.tar.bz2 \
-    && cd parallel-20210722 \
-    && ./configure \
-    && make \
-    && make install
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,15 @@ RUN wget https://get.helm.sh/helm-v3.6.0-linux-amd64.tar.gz && tar xzf helm-v3.6
 
 # jq
 RUN curl -o /usr/local/bin/jq -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 \
-    && chmod +x /usr/local/bin/jq \
-    && apt update \
-    && apt install -y parallel
+    && chmod +x /usr/local/bin/jq
+
+# parallel
+RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
+    && tar -xvjf parallel-20210722.tar.bz2 \
+    && cd parallel-20210722 \
+    && ./configure \
+    && make \
+    && make install
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
     && tar -xvjf parallel-20210722.tar.bz2 \
     && cd parallel-20210722 \
     && ./configure \
-    && chmod +x ./configure
+    && chmod +x ./configure \
     && make \
     && make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,7 @@ RUN curl -o /usr/local/bin/jq -L https://github.com/stedolan/jq/releases/downloa
     && chmod +x /usr/local/bin/jq
 
 # parallel
-RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
-    && tar -xvjf parallel-20210722.tar.bz2 \
-    && cd parallel-20210722 \
-    && ./configure \
-    && chmod +x ./configure \
-    && make \
-    && make install
+RUN apt update && apt install -y parallel
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN wget https://ftp.gnu.org/gnu/parallel/parallel-20210722.tar.bz2 \
     && tar -xvjf parallel-20210722.tar.bz2 \
     && cd parallel-20210722 \
     && ./configure \
+    && chmod +x ./configure
     && make \
     && make install
 


### PR DESCRIPTION
## 概要

* nightly の jenkins で使用している docker image を helm3 に移行
* 下記コマンドで image 内の helm が helm3 に移行できていることは確認済
```
$ docker run bitkey-platform/gcloud-sdk-python37-helm:helm3 helm version
version.BuildInfo{Version:"v3.6.0", GitCommit:"7f2df6467771a75f5646b7f12afb408590ed1755", GitTreeState:"clean", GoVersion:"go1.16.3"}
```
* parallel が使用できることを確認済
```
$ docker run "test/test-repo:test" parallel --version
GNU parallel 20161222
Copyright (C) 2007,2008,2009,2010,2011,2012,2013,2014,2015,2016
Ole Tange and Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
GNU parallel comes with no warranty.

Web site: http://www.gnu.org/software/parallel
```